### PR TITLE
Remove NOTE from R CMD check.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,12 +10,11 @@ Description: Choropleths are thematic maps where geographic regions, such as
     Google Maps. 
 Version: 4.0.0
 Authors@R: c(
-    person("Ari", "Lamstein", , "ari@lamsteinconsulting.com", c("aut", "cre")),
-    person("Zhaochen", "He", , "zhaochen.he@cnu.edu", role = "aut"),
+    person("Ari", "Lamstein", , "ari@lamsteinconsulting.com", "aut"),
+    person("Zhaochen", "He", , "zhaochen.he@cnu.edu", role = c("aut", "cre")),
     person("Brian", "Johnson", , role = "ctb"),
     person("Trulia, Inc.", role = c("cph"))
     )
-Maintainer: Zhaochen He <zhaocehn.he@cnu.edu>
 URL: https://github.com/eastnile/choroplethr
 Copyright: Trulia, Inc.
 License: BSD_3_clause + file LICENSE


### PR DESCRIPTION
As described here:

https://r-pkgs.org/description.html#sec-description-authors-at-r

The "Maintainer" field is no longer strictly necessary. The role "cre" means "maintainer". The old version of this file was causing a NOTE because Zhao was listed as the maintainer but I was listed with role "cre".